### PR TITLE
adapt mirage-crypto-rng usage to version 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/vendor/bundle
 ./twostep.exe
 ./twostep.install
 .ocamlinit
+_opam

--- a/lib/base32.ml
+++ b/lib/base32.ml
@@ -132,8 +132,7 @@ let base32_to_string base32 =
   in
   base2
   |> Z.of_string_base 2
-  |> Mirage_crypto_pk.Z_extra.to_cstruct_be ~size:(String.length base2 / 8)
-  |> Cstruct.to_string
+  |> Mirage_crypto_pk.Z_extra.to_octets_be ~size:(String.length base2 / 8)
 
 
 let char_to_bits char =

--- a/lib/dune
+++ b/lib/dune
@@ -4,5 +4,5 @@
  (synopsis "HOTP and TOTP algorithms for 2-step verification (for OCaml)")
  (instrumentation
   (backend bisect_ppx))
- (libraries base hex mirage-crypto mirage-crypto-pk mirage-crypto-rng
+ (libraries base digestif hex mirage-crypto mirage-crypto-pk mirage-crypto-rng
    mirage-crypto-rng.unix bisect_ppx))

--- a/lib/dune
+++ b/lib/dune
@@ -5,4 +5,4 @@
  (instrumentation
   (backend bisect_ppx))
  (libraries base digestif hex mirage-crypto mirage-crypto-pk mirage-crypto-rng
-   mirage-crypto-rng.unix bisect_ppx))
+   mirage-crypto-rng.unix))

--- a/lib/hmac.ml
+++ b/lib/hmac.ml
@@ -1,21 +1,21 @@
-module S1 = Mirage_crypto.Hash.SHA1
-module S2 = Mirage_crypto.Hash.SHA256
-module S5 = Mirage_crypto.Hash.SHA512
+module S1 = Digestif.SHA1
+module S2 = Digestif.SHA256
+module S5 = Digestif.SHA512
 
 let of_string = Cstruct.of_string
 
 let to_string = Cstruct.to_string
 
 let hmac_sha1 ~secret payload =
-  to_string @@ S1.hmac ~key:(of_string secret) @@ of_string payload
+  S1.to_raw_string @@ S1.hmac_string ~key:secret payload
 
 
 let hmac_sha256 ~secret payload =
-  to_string @@ S2.hmac ~key:(of_string secret) @@ of_string payload
+  S2.to_raw_string @@ S2.hmac_string ~key:secret payload
 
 
 let hmac_sha512 ~secret payload =
-  to_string @@ S5.hmac ~key:(of_string secret) @@ of_string payload
+  S5.to_raw_string @@ S5.hmac_string ~key:secret payload
 
 
 let no_trace char = char != '-'

--- a/lib/secret.ml
+++ b/lib/secret.ml
@@ -2,7 +2,7 @@ let __random_bytes bytes = Mirage_crypto_rng.generate bytes
 
 let generate ~bytes () =
   if bytes >= 10 && bytes mod 5 == 0
-  then Base32.string_to_base32 @@ Cstruct.to_string @@ __random_bytes bytes
+  then Base32.string_to_base32 @@ __random_bytes bytes
   else
     failwith
       ( "Invalid amount of bytes ("
@@ -10,4 +10,4 @@ let generate ~bytes () =
       ^ ") for secret, it must be at least 10 and divisible by 5!" )
 
 
-let _ = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
+let _ = Mirage_crypto_rng_unix.use_default ()

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -8,6 +8,5 @@ let counter ?(timestep = 30) ?(drift = 0) ?(timestamp = __unix_time) () =
   let ctr =
     Base.Int64.( + ) add @@ Base.Int64.( / ) now @@ Base.Int64.of_int timestep
   in
-  Cstruct.to_string
-  @@ Mirage_crypto_pk.Z_extra.to_cstruct_be ~size:8
+  Mirage_crypto_pk.Z_extra.to_octets_be ~size:8
   @@ Z.of_int64 ctr

--- a/lib/twostep.ml
+++ b/lib/twostep.ml
@@ -100,8 +100,7 @@ module HOTP : IHOTP = struct
     let decoded = Base32.base32_to_string secret in
     let counter = Base.Int64.of_int counter in
     let counter' =
-      Cstruct.to_string
-      @@ Mirage_crypto_pk.Z_extra.to_cstruct_be ~size:8
+      Mirage_crypto_pk.Z_extra.to_octets_be ~size:8
       @@ Z.of_int64 counter
     in
     let image = Hmac.hmac ~hash ~secret:decoded counter' in

--- a/test/api_interface.ml
+++ b/test/api_interface.ml
@@ -200,5 +200,5 @@ let suite =
 
 
 let () =
-  Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna) ;
+  Mirage_crypto_rng_unix.use_default () ;
   run "Twostep tests" [ ("test suite", suite) ]

--- a/twostep.opam
+++ b/twostep.opam
@@ -28,8 +28,9 @@ available: [ arch != "arm32" & arch != "x86_32" ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "base" {>= "v0.9.3"}
+  "digestif" {>= "1.0.0"}
   "hex" {>= "1.2.0"}
-  "mirage-crypto" {>= "0.11.0"}
+  "mirage-crypto" {>= "1.0.0"}
   "mirage-crypto-rng"
   "mirage-crypto-pk"
   "dune" {>= "2.7.0"}

--- a/twostep.opam
+++ b/twostep.opam
@@ -30,7 +30,7 @@ depends: [
   "base" {>= "v0.9.3"}
   "digestif" {>= "1.0.0"}
   "hex" {>= "1.2.0"}
-  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto" {>= "1.2.0"}
   "mirage-crypto-rng"
   "mirage-crypto-pk"
   "dune" {>= "2.7.0"}


### PR DESCRIPTION
I've updated the code to work with `mirage-crypto > 1`. I don't know much about what this lib is doing, the modifications were mainly based on type signatures. The local tests are passing, which is a promising sign.